### PR TITLE
Export in main

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,0 +1,22 @@
+import * as ts from 'typescript';
+
+import { CProgram } from './src/program';
+
+export function transpile(source: string): string {
+    var sourceFile = ts.createSourceFile('source.ts', source, ts.ScriptTarget.ES5, true);
+    var compilerHost: ts.CompilerHost = {
+        getSourceFile: (fileName, target) => 'source.ts' ? sourceFile : null,
+        writeFile: (name, text, writeByteOrderMark) => { },
+        getDefaultLibFileName: () => { return "lib.d.ts"; },
+        useCaseSensitiveFileNames: () => { return false; },
+        getCanonicalFileName: fileName => fileName,
+        getCurrentDirectory: () => "",
+        getDirectories: () => [],
+        getNewLine: () => "\n",
+        fileExists: fileName => fileName == 'source.ts',
+        readFile: fileName => fileName == 'source.ts' ? source : null,
+        directoryExists: dirName => dirName == "",
+    };
+    var program = ts.createProgram(['source.ts'], { noLib: true }, compilerHost);
+    return new CProgram(program)["resolve"]();
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ts2c",
   "version": "2.1.0",
   "description": "TypeScript/JavaScript to C transpiler",
-  "main": "ts2c.js",
+  "main": "main.js",
   "bin": {
     "ts2c": "./bin/ts2c"
   },
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "prepublish": "tsc",
-    "build": "browserify ts2c.js -x typescript > ts2c.bundle.js",
+    "build": "browserify main.js -x typescript -s ts2c -o ts2c.bundle.js",
     "cover": "cd tests && make -B cover",
     "test": "cd tests && make -B"
   },


### PR DESCRIPTION
This is a work in progress for #9 that can be built on.

* A new, simplified main file to export the `transpile` function (for both node and browser)
* Usage of browserify's `-s ts2c` to handle the export
* Update of `package.json` `main` field to point to the new file

The "old" main file is still included, as I didn't manage to fix the tests when pointing to the new one. (They don't run on Windows, so it was a pain to try.)